### PR TITLE
SSGに関する記述を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,6 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-## TODO: Static Build
-
-First, execute the following command. This will generate the output files in the `out/` directory.
-
-```bash
-yarn build
-```
-
-To start the server using `http-server`
-
-```bash
-http-server out
-```
-
-Open [http://127.0.0.1:8081/](http://127.0.0.1:8081/) with your browser to see the result.
-
 ## バージョン管理
 
 パッケージのバージョンと git のバージョンを同期させるため、PR 段階でのバージョン上げは`--no-git-tag-version`オプションを付けて実施する。

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 ## バージョン管理
 
-パッケージのバージョンと git のバージョンを同期させるため、PR 段階でのバージョン上げは`--no-git-tag-version`オプションを付けて実施する。
+以下のコマンドにより、`package.json`のバージョンが上がる
 
 ```bash
-yarn version --patch --no-git-tag-version
+yarn version patch --immediate
 ```
 
 また、`main`ブランチマージ時に、`package.json`のバージョン内容をもとに自動的にタグが切られる。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-starter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/atoms/ButtonSample.tsx
+++ b/src/components/atoms/ButtonSample.tsx
@@ -2,9 +2,12 @@ import ThemeContext from "@/app/use-context-sample/themeContext";
 import { useContext } from "react";
 
 export default function ButtonSample() {
+  // const theme = useContext(ThemeContext);
+
   return (
     <>
       <h3>This is button sample</h3>
+      {/* <p>theme is {theme}</p> */}
     </>
   );
 }


### PR DESCRIPTION
## 概要
SSGに関する記述を削除

## 修正内容
* 既存の実装ではSSGはできないので、READMEからSSGに関する記述を削除
* `themecontext`の仕様方法をコメントアウトで記載
* `package.json`のバージョンの上げ方記載

## 備考
https://yarnpkg.com/cli/version


https://qiita.com/whopper1962/items/1d1a7179845b3e1d3084#%E6%9D%A1%E4%BB%B6-2

> useEffect、useState、onClickなどのブラウザ依存の機能を使用していない

この条件に該当しない
